### PR TITLE
[Examples #28 reporting results]

### DIFF
--- a/.github/workflows/codeceptjs-reporting.yml
+++ b/.github/workflows/codeceptjs-reporting.yml
@@ -18,10 +18,11 @@ on:
         required: false
   schedule:
     - cron: "*/30 * * * *"
+    branches:
+      - examples-28-reporting-results
 
 jobs:
   reporting:
-
     runs-on: ubuntu-latest
 
     steps:

--- a/.github/workflows/codeceptjs-reporting.yml
+++ b/.github/workflows/codeceptjs-reporting.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Generate unique run value
       id: generate-run
       run: echo "::set-output name=run_value::$(date +%s)"
-    - run: npx codeceptjs run"
+    - run: npx codeceptjs run
       env:
         TESTOMATIO: "${{ secrets.TESTOMATIO }}"
         TESTOMATIO_URL: "${{ secrets.TESTOMATIO_URL }}"

--- a/.github/workflows/codeceptjs-reporting.yml
+++ b/.github/workflows/codeceptjs-reporting.yml
@@ -17,9 +17,7 @@ on:
       browsers:
         required: false
   schedule:
-    - cron: "*/30 * * * *"
-    branches:
-      - examples-28-reporting-results
+    - cron: "*/20 * * * *"
 
 jobs:
   reporting:
@@ -27,6 +25,8 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      with:
+        ref: examples-28-reporting-results
     - name: Setup node
       uses: actions/setup-node@v1
       with:

--- a/.github/workflows/codeceptjs-reporting.yml
+++ b/.github/workflows/codeceptjs-reporting.yml
@@ -1,21 +1,11 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 # - cron: "0 8 * * *"
-name: CodeceptJS examples TESTOMATIO reporting
+name: CodeceptJS example reporting results
 
 on:
-  workflow_dispatch:
-    inputs:
-      testomatio:
-        required: false
-      testomatio_url:
-        required: false
-      run:
-        required: false
-      browsers:
-        required: false
   schedule:
-    - cron: "*/15 * * * *"
+    - cron: "0 8 * * *"
 
 jobs:
   reporting:
@@ -24,27 +14,18 @@ jobs:
     strategy:
       matrix:
         node-version: [18.x]
-        branch:
-         - examples-28-reporting-results
 
     steps:
-      - name: checkout branch for schedule event
-        if: (github.event_name == 'schedule') #for schedule event, checkout matrix branches seperately.
-        uses: actions/checkout@v3
-        with:
-          ref: ${{ matrix.branch }}
-      - name: Setup node
+      - uses: actions/checkout@v3
+      - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:
           node-version: ${{ matrix.node-version }}
-      - name: Switch to the codeceptJS example dir
-        run: cd codeceptJS/
       - name: Dependencies installing
-        run: npm i
-      - name: Generate unique run value
-        id: generate-run
-        run: echo "::set-output name=run_value::$(date +%s)"
-      - run: npx codeceptjs run
+        run: npm ci
+      - name: execute tests
+        continue-on-error: true
+        run: npx codeceptjs run
         env:
           TESTOMATIO: "${{ secrets.TESTOMATIO }}"
           TESTOMATIO_URL: "${{ secrets.TESTOMATIO_URL }}"

--- a/.github/workflows/codeceptjs-reporting.yml
+++ b/.github/workflows/codeceptjs-reporting.yml
@@ -1,8 +1,6 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
 # - cron: "0 8 * * *"
-
-
 name: CodeceptJS examples TESTOMATIO reporting
 
 on:
@@ -17,29 +15,37 @@ on:
       browsers:
         required: false
   schedule:
-    - cron: "*/20 * * * *"
+    - cron: "*/15 * * * *"
 
 jobs:
   reporting:
     runs-on: ubuntu-latest
 
+    strategy:
+      matrix:
+        node-version: [18.x]
+        branch:
+         - examples-28-reporting-results
+
     steps:
-    - uses: actions/checkout@v2
-      with:
-        ref: examples-28-reporting-results
-    - name: Setup node
-      uses: actions/setup-node@v1
-      with:
-        node-version: 18.x
-    - name: Switch to the codeceptJS example dir
-      run: cd codeceptJS/
-    - name: Dependencies installing
-      run: npm i
-    - name: Generate unique run value
-      id: generate-run
-      run: echo "::set-output name=run_value::$(date +%s)"
-    - run: npx codeceptjs run
-      env:
-        TESTOMATIO: "${{ secrets.TESTOMATIO }}"
-        TESTOMATIO_URL: "${{ secrets.TESTOMATIO_URL }}"
-        CODECEPT_GROUP_TESTS: "${{ secrets.CODECEPT_GROUP_TESTS }}"
+      - name: checkout branch for schedule event
+        if: (github.event_name == 'schedule') #for schedule event, checkout matrix branches seperately.
+        uses: actions/checkout@v3
+        with:
+          ref: ${{ matrix.branch }}
+      - name: Setup node
+        uses: actions/setup-node@v3
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Switch to the codeceptJS example dir
+        run: cd codeceptJS/
+      - name: Dependencies installing
+        run: npm i
+      - name: Generate unique run value
+        id: generate-run
+        run: echo "::set-output name=run_value::$(date +%s)"
+      - run: npx codeceptjs run
+        env:
+          TESTOMATIO: "${{ secrets.TESTOMATIO }}"
+          TESTOMATIO_URL: "${{ secrets.TESTOMATIO_URL }}"
+          CODECEPT_GROUP_TESTS: "${{ secrets.CODECEPT_GROUP_TESTS }}"

--- a/.github/workflows/codeceptjs-reporting.yml
+++ b/.github/workflows/codeceptjs-reporting.yml
@@ -1,15 +1,13 @@
 # This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
 # For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+# - cron: "0 8 * * *"
+
 
 name: CodeceptJS examples TESTOMATIO reporting
 
 on:
   workflow_dispatch:
     inputs:
-      grep:
-        description: 'A grep '
-        required: false
-        default: ''
       testomatio:
         required: false
       testomatio_url:
@@ -19,7 +17,7 @@ on:
       browsers:
         required: false
   schedule:
-    - cron: "0 8 * * *"
+    - cron: "*/30 * * * *"
 
 jobs:
   reporting:
@@ -32,11 +30,14 @@ jobs:
       uses: actions/setup-node@v1
       with:
         node-version: 18.x
-    - run: npm i
+    - name: Switch to the codeceptJS example dir
+      run: cd codeceptJS/
+    - name: Dependencies installing
+      run: npm i
     - name: Generate unique run value
       id: generate-run
       run: echo "::set-output name=run_value::$(date +%s)"
-    - run: npx codeceptjs run --grep "${{ github.event.inputs.grep }}"
+    - run: npx codeceptjs run"
       env:
         TESTOMATIO: "${{ secrets.TESTOMATIO }}"
         TESTOMATIO_URL: "${{ secrets.TESTOMATIO_URL }}"

--- a/.github/workflows/codeceptjs-reporting.yml
+++ b/.github/workflows/codeceptjs-reporting.yml
@@ -17,6 +17,8 @@ jobs:
 
     steps:
       - uses: actions/checkout@v3
+      - name: Switch example branch
+        run: cd codeceptJS/
       - name: Use Node.js ${{ matrix.node-version }}
         uses: actions/setup-node@v3
         with:

--- a/codeceptJS/.github/workflows/report-codeceptjs.yml
+++ b/codeceptJS/.github/workflows/report-codeceptjs.yml
@@ -40,5 +40,4 @@ jobs:
       env:
         TESTOMATIO: "${{ secrets.TESTOMATIO }}"
         TESTOMATIO_URL: "${{ secrets.TESTOMATIO_URL }}"
-        TESTOMATIO_RUN: "${{ steps.generate-run.outputs.run_value }}"
         CODECEPT_GROUP_TESTS: "${{ secrets.CODECEPT_GROUP_TESTS }}"

--- a/codeceptJS/.github/workflows/report-codeceptjs.yml
+++ b/codeceptJS/.github/workflows/report-codeceptjs.yml
@@ -41,4 +41,4 @@ jobs:
         TESTOMATIO: "${{ secrets.TESTOMATIO }}"
         TESTOMATIO_URL: "${{ secrets.TESTOMATIO_URL }}"
         TESTOMATIO_RUN: "${{ steps.generate-run.outputs.run_value }}"
-        codecept_GROUP_TESTS: "${{ secrets.codecept_GROUP_TESTS }}"
+        CODECEPT_GROUP_TESTS: "${{ secrets.CODECEPT_GROUP_TESTS }}"

--- a/codeceptJS/.github/workflows/report-codeceptjs.yml
+++ b/codeceptJS/.github/workflows/report-codeceptjs.yml
@@ -38,7 +38,7 @@ jobs:
       run: echo "::set-output name=run_value::$(date +%s)"
     - run: npx codeceptjs run --grep "${{ github.event.inputs.grep }}"
       env:
-        TESTOMATIO: "${{ secrets.testomatio }}"
-        TESTOMATIO_URL: "${{ secrets.testomatio_url }}"
+        TESTOMATIO: "${{ secrets.TESTOMATIO }}"
+        TESTOMATIO_URL: "${{ secrets.TESTOMATIO_URL }}"
         TESTOMATIO_RUN: "${{ steps.generate-run.outputs.run_value }}"
         codecept_GROUP_TESTS: "${{ secrets.codecept_GROUP_TESTS }}"

--- a/codeceptJS/.github/workflows/report-codeceptjs.yml
+++ b/codeceptJS/.github/workflows/report-codeceptjs.yml
@@ -1,0 +1,44 @@
+# This workflow will do a clean install of node dependencies, build the source code and run tests across different versions of node
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-nodejs-with-github-actions
+
+name: CodeceptJS examples TESTOMATIO reporting
+
+on:
+  workflow_dispatch:
+    inputs:
+      grep:
+        description: 'A grep '
+        required: false
+        default: ''
+      testomatio:
+        required: false
+      testomatio_url:
+        required: false
+      run:
+        required: false
+      browsers:
+        required: false
+  schedule:
+    - cron: "0 8 * * *"
+
+jobs:
+  reporting:
+
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Setup node
+      uses: actions/setup-node@v1
+      with:
+        node-version: 18.x
+    - run: npm i
+    - name: Generate unique run value
+      id: generate-run
+      run: echo "::set-output name=run_value::$(date +%s)"
+    - run: npx codeceptjs run --grep "${{ github.event.inputs.grep }}"
+      env:
+        TESTOMATIO: "${{ secrets.testomatio }}"
+        TESTOMATIO_URL: "${{ secrets.testomatio_url }}"
+        TESTOMATIO_RUN: "${{ steps.generate-run.outputs.run_value }}"
+        codecept_GROUP_TESTS: "${{ secrets.codecept_GROUP_TESTS }}"

--- a/codeceptJS/codecept.conf.js
+++ b/codeceptJS/codecept.conf.js
@@ -4,12 +4,17 @@ const { setHeadlessWhen } = require('@codeceptjs/configure');
 
 setHeadlessWhen(process.env.HEADLESS);
 
+const tests = process.env.codecept_GROUP_TESTS === "quick"
+          ? './todomvc-tests/todo-mvc_test.js'
+          : './todomvc-tests/**/*_test.js'
+
 exports.config = {
-  tests: './todomvc-tests/**/*_test.js',
+  tests,
   output: './output',
   helpers: {
     Playwright: {
       video: true,
+      trace: false,
       url: 'http://localhost',
       waitForTimeout: 5000,
       waitForNavigation: 'networkidle0',
@@ -33,6 +38,9 @@ exports.config = {
       require: '@testomatio/reporter/lib/adapter/codecept',
       apiKey:  process.env.TESTOMATIO,
     },
+    screenshotOnFail: {
+      enabled: false
+    }
   },
   bootstrap: null,
   mocha: {},

--- a/codeceptJS/package.json
+++ b/codeceptJS/package.json
@@ -27,6 +27,6 @@
   "devDependencies": {
     "@codeceptjs/configure": "^0.10.0",
     "@codeceptjs/ui": "^0.5.0",
-    "codeceptjs": "^3.4.1"
+    "codeceptjs": "^3.5.2"
   }
 }

--- a/codeceptJS/package.json
+++ b/codeceptJS/package.json
@@ -1,19 +1,19 @@
 {
   "name": "@codeceptjs/examples",
-  "version": "1.1.2",
+  "version": "1.1.3",
   "main": "index.js",
   "scripts": {
     "test": "echo \"Error: no test specified\" && exit 1"
   },
   "keywords": [],
-  "author": "kaflan, davert",
+  "author": "kaflan, davert, mihaylukvv",
   "license": "ISC",
   "dependencies": {
-    "@testomatio/reporter": "0.8.1",
-    "axios": "^0.19.2",
-    "check-tests": "^0.7.6",
-    "dotenv": "^8.6.0",
-    "playwright": "^1.23.0"
+    "@testomatio/reporter": "1.0.0",
+    "axios": "^1.4.0",
+    "check-tests": "^0.8.16",
+    "dotenv": "^16.3.1",
+    "playwright": "^1.36.0"
   },
   "repository": {
     "type": "git",
@@ -23,10 +23,10 @@
     "url": "https://github.com/codecept-js/examples/issues"
   },
   "homepage": "https://github.com/codecept-js/examples#readme",
-  "description": "",
+  "description": "Running and Monitoring CodeceptJS Tests with TESTOMATIO Reporter",
   "devDependencies": {
-    "@codeceptjs/configure": "^0.4.0",
-    "@codeceptjs/ui": "^0.2.0",
-    "codeceptjs": "^3.3.3"
+    "@codeceptjs/configure": "^0.10.0",
+    "@codeceptjs/ui": "^0.5.0",
+    "codeceptjs": "^3.4.1"
   }
 }

--- a/codeceptJS/todomvc-tests/todo-mvc_test.js
+++ b/codeceptJS/todomvc-tests/todo-mvc_test.js
@@ -3,6 +3,8 @@ Feature('codepress demo')
 Before(async ({ I }) => {
   I.amOnPage('http://todomvc.com/examples/angularjs/#/')
 
+  console.log("Test Before hoooks quick test");
+
   I.say('Given I already have some todos')
   const todoItems = [
     {title: 'Create a cypress like runner for CodeceptJS', completed: false},


### PR DESCRIPTION
Task - https://github.com/testomatio/examples/issues/28

I have added a new Github CI action for CodeceptJS examples which will send test results to TESTOMATIO prod report every day (or 3 days)

- a new secret.keys to Github Settings
- a new `examples/codeceptjs/report-codeceptjs.yml` file
- a new workflow
- up npm package versions to the latest ones (`examples/codeceptjs`)

WIP: do all the above for Playwright + Cypress...