### PR TITLE
[GITHUB REPORTING] execute tests each 6 days instead of 2

### DIFF
--- a/.github/workflows/codeceptjs-reporting.yml
+++ b/.github/workflows/codeceptjs-reporting.yml
@@ -5,7 +5,7 @@ name: CodeceptJS example reporting results
 
 on:
   schedule:
-    - cron: "0 5 */2 * *"
+    - cron: "0 5 */6 * *"
 
 jobs:
   reporting:

--- a/.github/workflows/cypress-reporting.yml
+++ b/.github/workflows/cypress-reporting.yml
@@ -5,7 +5,7 @@ name: Cypress example reporting results
 
 on:
   schedule:
-    - cron: "10 5 */2 * *"
+    - cron: "10 5 */6 * *"
 
 jobs:
   reporting:

--- a/.github/workflows/playwright-reporting.yml
+++ b/.github/workflows/playwright-reporting.yml
@@ -5,7 +5,7 @@ name: Playwright example reporting results
 
 on:
   schedule:
-    - cron: "20 5 */2 * *"
+    - cron: "20 5 */6 * *"
 
 jobs:
   reporting:


### PR DESCRIPTION
Github reporting actions => execute tests each 6 days instead of 2